### PR TITLE
Fix line comment split problem

### DIFF
--- a/smck/Parser/ParsingBase.swift
+++ b/smck/Parser/ParsingBase.swift
@@ -221,7 +221,7 @@ class ParsingBase {
         let regexBlock = try! NSRegularExpression(pattern: annotationBlockPattern, options: NSRegularExpression.Options(rawValue:0))
         let regexLine = try! NSRegularExpression(pattern: annotationLinePattern, options: NSRegularExpression.Options(rawValue:0))
         var newStr = ""
-        newStr = regexLine.stringByReplacingMatches(in: content, options: NSRegularExpression.MatchingOptions(rawValue:0), range: NSMakeRange(0, content.characters.count), withTemplate: Sb.space)
+        newStr = regexLine.stringByReplacingMatches(in: content, options: NSRegularExpression.MatchingOptions(rawValue:0), range: NSMakeRange(0, content.characters.count), withTemplate: Sb.newLine)
         newStr = regexBlock.stringByReplacingMatches(in: newStr, options: NSRegularExpression.MatchingOptions(rawValue:0), range: NSMakeRange(0, newStr.characters.count), withTemplate: Sb.space)
         return newStr
     }


### PR DESCRIPTION
~~~objc
@property (nonatomic, copy) NSString *test1; // line comment
@property (nonatomic, copy) NSString *test2; // line comment
~~~

以上这种场景的注释切割不准确，如果用空格替换，会将这 2 行合并为 1 行