### PR TITLE
Fix category parse error

### DIFF
--- a/smck/Parser/ParsingInterface.swift
+++ b/smck/Parser/ParsingInterface.swift
@@ -40,10 +40,13 @@ class ParsingInterface {
             } else if inCategoryTf && tk != Sb.rBktR && !inProtocolTf {
                 inObject.category = tk
             } else if inCategoryTf && tk == Sb.rBktR {
+                // 检测到右括号说明 Category 检测完毕
+                inCategoryTf = false
+                
                 if inObject.category.isEmpty {
+                    // 为 Extension 添加 void 与 Category 区分开
                     inObject.category = "void"
                 }
-                inCategoryTf = false
             } else if tk == Sb.agBktL && !inProtocolTf {
                 inProtocolTf = true
             } else if tk != Sb.comma && tk != Sb.agBktR && inProtocolTf {

--- a/smck/Parser/ParsingInterface.swift
+++ b/smck/Parser/ParsingInterface.swift
@@ -39,6 +39,11 @@ class ParsingInterface {
                 inSuperNameTf = false
             } else if inCategoryTf && tk != Sb.rBktR && !inProtocolTf {
                 inObject.category = tk
+            } else if inCategoryTf && tk == Sb.rBktR {
+                if inObject.category.isEmpty {
+                    inObject.category = "void"
+                }
+                inCategoryTf = false
             } else if tk == Sb.agBktL && !inProtocolTf {
                 inProtocolTf = true
             } else if tk != Sb.comma && tk != Sb.agBktR && inProtocolTf {


### PR DESCRIPTION
解析 Category 遇到 `@interface XXObject () <XXDelegate1, XXDelegate2>` 时解析有误